### PR TITLE
Use number input type as example for non-auto-directionality form-associated input element

### DIFF
--- a/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js
+++ b/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.js
@@ -383,7 +383,7 @@ test(() => {
   `);
   let inp = tree.querySelector("input");
   assert_equals(html_direction(inp), "rtl");
-  inp.type = "month";
+  inp.type = "number";
   assert_equals(html_direction(inp), "ltr");
   tree.remove();
 }, 'input direction changes if it stops being auto-directionality form-associated');


### PR DESCRIPTION
The subtest ensures that the text direction reverts to `ltr` if an input element stops being [auto-directionality form-associated](https://html.spec.whatwg.org/#auto-directionality-form-associated-elements). For this, the test changes an input element's type to `month`. Gecko and WebKit do not support `type=month` and therefore fail the test. This change uses `type=number` instead so that both pass the subtest.